### PR TITLE
图库初始化时滚动到底部

### DIFF
--- a/Photos/Views/PhotosGridView.swift
+++ b/Photos/Views/PhotosGridView.swift
@@ -24,6 +24,7 @@ struct PhotosGridView: View {
                 }
             }
         }
+        .defaultScrollAnchor(.bottom)
         .ignoresSafeArea(edges: .top)
         .navigationTitle("图库")
         .toolbar {


### PR DESCRIPTION
## 功能说明
- 图库视图初始化时自动定位到底部，显示最新照片
- 使用 `.defaultScrollAnchor(.bottom)` 实现无动画的直接定位
- 系统自动处理底部安全区域，避让 tab bar

## 技术实现
- 使用 iOS 17+ 的 `.defaultScrollAnchor(.bottom)` API
- 无需手动计算滚动位置和安全区域
- 代码简洁，性能优秀

## 测试计划
- [ ] iPhone 上打开图库标签，确认定位在底部
- [ ] iPad 上打开图库标签，确认定位在底部
- [ ] 确认最后一张照片不被 tab bar 遮挡
- [ ] 确认没有滚动动画，直接显示底部内容
- [ ] 切换到精选集再切回图库，确认保持在底部